### PR TITLE
style: apply clippy lints

### DIFF
--- a/src/lemmy/api.rs
+++ b/src/lemmy/api.rs
@@ -27,11 +27,11 @@ impl API {
         }
     }
 
-    pub async fn login(&self, username: &String, password: &String, two_factor_token: Option<String>) -> Result<String, Error> {
+    pub async fn login(&self, username: &str, password: &str, two_factor_token: Option<String>) -> Result<String, Error> {
         let url = self.instance.join("/api/v3/user/login").unwrap();
         let params = person::Login {
-            username_or_email: Sensitive::new(username.clone()),
-            password: Sensitive::new(password.clone()),
+            username_or_email: Sensitive::new(username.to_string()),
+            password: Sensitive::new(password.to_string()),
             totp_2fa_token: two_factor_token,
         };
     
@@ -55,10 +55,10 @@ impl API {
         }
     }
 
-    pub async fn fetch_profile_settings(&self, jwt_token: &String) -> Result<site::GetSiteResponse, Error> {
+    pub async fn fetch_profile_settings(&self, jwt_token: &str) -> Result<site::GetSiteResponse, Error> {
         let url = self.instance.join("/api/v3/site").unwrap();
         let params = site::GetSite {
-            auth: Some(Sensitive::new(jwt_token.clone())),
+            auth: Some(Sensitive::new(jwt_token.to_string())),
         };
     
         let response: Response = self.client
@@ -81,13 +81,13 @@ impl API {
         }
     }
 
-    pub async fn fetch_community_by_name(&self, jwt_token: &String, name: &String) -> 
+    pub async fn fetch_community_by_name(&self, jwt_token: &str, name: &str) -> 
         Result<community::GetCommunityResponse, Error> {
 
         let url = self.instance.join("/api/v3/community").unwrap();
         let params = community::GetCommunity {
-            name: Some(name.clone()),
-            auth: Some(Sensitive::new(jwt_token.clone())),
+            name: Some(name.to_string()),
+            auth: Some(Sensitive::new(jwt_token.to_string())),
             ..Default::default()
         };
     
@@ -112,14 +112,14 @@ impl API {
     }
 
     pub async fn block_community(&self,
-        jwt_token: &String,
+        jwt_token: &str,
         community_id: newtypes::CommunityId) -> Result<community::BlockCommunityResponse, Error> {
 
         let url = self.instance.join("/api/v3/community/block").unwrap();
         let params = community::BlockCommunity {
             community_id,
             block: true,
-            auth: Sensitive::new(jwt_token.clone()),
+            auth: Sensitive::new(jwt_token.to_string()),
         };
     
         let response: Response = self.client
@@ -143,14 +143,14 @@ impl API {
     }
 
     pub async fn follow_community(&self,
-        jwt_token: &String,
+        jwt_token: &str,
         community_id: newtypes::CommunityId) -> Result<community::CommunityResponse, Error> {
 
         let url = self.instance.join("/api/v3/community/follow").unwrap();
         let params = community::FollowCommunity {
             community_id,
             follow: true,
-            auth: Sensitive::new(jwt_token.clone()),
+            auth: Sensitive::new(jwt_token.to_string()),
         };
     
         let response: Response = self.client
@@ -173,13 +173,13 @@ impl API {
         }
     }
 
-    pub async fn fetch_user_details(&self, jwt_token: &String, name: &String) -> 
+    pub async fn fetch_user_details(&self, jwt_token: &str, name: &str) -> 
         Result<person::GetPersonDetailsResponse, Error> {
 
         let url = self.instance.join("/api/v3/user").unwrap();
         let params = person::GetPersonDetails {
-            username: Some(name.clone()),
-            auth: Some(Sensitive::new(jwt_token.clone())),
+            username: Some(name.to_string()),
+            auth: Some(Sensitive::new(jwt_token.to_string())),
             ..Default::default()
         };
     
@@ -204,14 +204,14 @@ impl API {
     }
 
     pub async fn block_user(&self,
-        jwt_token: &String,
+        jwt_token: &str,
         person_id: newtypes::PersonId) -> Result<person::BlockPersonResponse, Error> {
 
         let url = self.instance.join("/api/v3/user/block").unwrap();
         let params = person::BlockPerson {
             person_id,
             block: true,
-            auth: Sensitive::new(jwt_token.clone()),
+            auth: Sensitive::new(jwt_token.to_string()),
         };
     
         let response: Response = self.client
@@ -235,12 +235,12 @@ impl API {
     }
 
     pub async fn save_user_settings(&self,
-        jwt_token: &String,
+        jwt_token: &str,
         user_settings_local: profile::ProfileSettings) -> Result<person::LoginResponse, Error> {
 
         let url = self.instance.join("/api/v3/user/save_user_settings").unwrap();
         let mut user_settings_api = profile::construct_settings(&user_settings_local);
-        user_settings_api.auth = Sensitive::new(jwt_token.clone());
+        user_settings_api.auth = Sensitive::new(jwt_token.to_string());
     
         let response: Response = self.client
             .put(url)

--- a/src/lemmy/api.rs
+++ b/src/lemmy/api.rs
@@ -10,18 +10,18 @@ use reqwest::Error;
 use url::Url;
 use crate::profile;
 
-pub struct API {
+pub struct Api {
     client: Client,
     instance: Url,
 }
 
-impl API {
-    pub fn new(instance: Url) -> API {
+impl Api {
+    pub fn new(instance: Url) -> Api {
         let mut client_builder = ClientBuilder::new();
         client_builder = client_builder.user_agent("LASIM - https://github.com/CMahaff/lasim");
         let new_client = client_builder.build().unwrap();
 
-        return API {
+        return Api {
             client: new_client,
             instance,
         }

--- a/src/lemmy/typecast.rs
+++ b/src/lemmy/typecast.rs
@@ -13,8 +13,8 @@ impl ToAPI {
         return new_languages;
     }
 
-    pub fn cast_sort_type(original_sort: &String) -> lemmy_db_schema::SortType {
-        match original_sort.as_str() {
+    pub fn cast_sort_type(original_sort: &str) -> lemmy_db_schema::SortType {
+        match original_sort {
             "Active" => lemmy_db_schema::SortType::Active,
             "Hot" => lemmy_db_schema::SortType::Hot,
             "New" => lemmy_db_schema::SortType::New,
@@ -36,8 +36,8 @@ impl ToAPI {
         }
     }
 
-    pub fn cast_listing_type(original_type: &String) -> lemmy_db_schema::ListingType {
-        match original_type.as_str() {
+    pub fn cast_listing_type(original_type: &str) -> lemmy_db_schema::ListingType {
+        match original_type {
             "All" =>lemmy_db_schema::ListingType::All,
             "Local" => lemmy_db_schema::ListingType::Local,
             "Subscribed" => lemmy_db_schema::ListingType::Subscribed,

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ fn write_profile(profile_local: &profile::ProfileConfiguration, mut logger: impl
     };
 
     let json_string = serde_json::to_string_pretty(&profile_local);
-    match file.write_all(format!("{}", json_string.unwrap()).as_bytes()) {
+    match file.write_all(json_string.unwrap().as_bytes()) {
         Ok(_) => {
             logger(format!("Wrote Profile to: {}", path.to_str().unwrap()))
         },
@@ -141,7 +141,7 @@ async fn process_upload(processing_instruction: ProcessingInstruction, mut logge
     let original_profile = match read_profile() {
         Ok(profile) => profile,
         Err(e) => {
-            logger(format!("{}", e).to_string());
+            logger(e);
             return;
         },
     };
@@ -292,7 +292,7 @@ async fn process_upload(processing_instruction: ProcessingInstruction, mut logge
         logger(format!("Cannot save profile settings, got exception {}", save_settings_result.unwrap_err()));
     }
 
-    logger(format!("Finished!"));
+    logger("Finished!".to_string());
 }
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 #![windows_subsystem = "windows"]
+#![allow(clippy::needless_return)]
 
 mod lemmy;
 mod profile;

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ struct ProcessingInstruction {
 
 fn write_panic_info(info: &String) {
     let path = Path::new(PANIC_LOG);
-    let mut file = match File::create(&path) {
+    let mut file = match File::create(path) {
         Ok(file) => file,
         Err(_) => return
     };
@@ -56,7 +56,7 @@ fn evaluate_two_factor_token(token: &String) -> Result<Option<String>, &str> {
 fn write_profile(profile_local: &profile::ProfileConfiguration, mut logger: impl FnMut(String)) {
     let profile_filename = migrations::profile_migrate::get_latest_profile_name();
     let path = Path::new(profile_filename.as_str());
-    let mut file = match File::create(&path) {
+    let mut file = match File::create(path) {
         Ok(file) => file,
         Err(e) => {
             logger(format!("ERROR: Cannot write file - {}: {}", path.display(), e));

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,7 @@ async fn process_download(processing_instruction: ProcessingInstruction, mut log
     }
     let instance_url = instance_url_result.unwrap();
 
-    let api = lemmy::api::API::new(instance_url);
+    let api = lemmy::api::Api::new(instance_url);
 
     // Login
     logger(format!("Logging in as {}", username));
@@ -168,7 +168,7 @@ async fn process_upload(processing_instruction: ProcessingInstruction, mut logge
     }
     let instance_url = instance_url_result.unwrap();
 
-    let api = lemmy::api::API::new(instance_url);
+    let api = lemmy::api::Api::new(instance_url);
 
     // Login
     logger(format!("Logging in as {}", username));

--- a/src/migrations/profile_migrate.rs
+++ b/src/migrations/profile_migrate.rs
@@ -10,20 +10,17 @@ pub fn read_latest_profile() -> Result<profile::ProfileConfiguration, String> {
     // Identify latest profile version
     let mut latest_profile_version: u16 = 0;
     let directory_items = std::fs::read_dir("./").unwrap();
-    for item in directory_items {
-        if item.is_ok() {
-            let dir_entry = item.unwrap();
-            let metadata = std::fs::metadata(dir_entry.path());
-            if metadata.is_ok_and(|m| m.is_file()) {
-                let filename = String::from(dir_entry.file_name().to_str().unwrap());
-                if filename.starts_with(PROFILE_FILENAME_START) && filename.ends_with(PROFILE_FILENAME_END) {
-                    let end_index = filename.find(PROFILE_FILENAME_END).unwrap();
-                    let profile_version_string = filename.get(PROFILE_FILENAME_START.char_indices().count()..end_index);
-                    let profile_version = profile_version_string.unwrap().parse::<u16>().unwrap();
+    for dir_entry in directory_items.flatten() {
+        let metadata = std::fs::metadata(dir_entry.path());
+        if metadata.is_ok_and(|m| m.is_file()) {
+            let filename = String::from(dir_entry.file_name().to_str().unwrap());
+            if filename.starts_with(PROFILE_FILENAME_START) && filename.ends_with(PROFILE_FILENAME_END) {
+                let end_index = filename.find(PROFILE_FILENAME_END).unwrap();
+                let profile_version_string = filename.get(PROFILE_FILENAME_START.char_indices().count()..end_index);
+                let profile_version = profile_version_string.unwrap().parse::<u16>().unwrap();
 
-                    if profile_version > latest_profile_version {
-                        latest_profile_version = profile_version;
-                    }
+                if profile_version > latest_profile_version {
+                    latest_profile_version = profile_version;
                 }
             }
         }
@@ -43,8 +40,8 @@ pub fn read_latest_profile() -> Result<profile::ProfileConfiguration, String> {
     }
 
     if latest_profile_version == PROFILE_CURRENT_VERSION {
-        if profile_v1.is_some() {
-            profile_v2 = Some(migrations::migrate_v1_to_v2::convert_profile(profile_v1.unwrap()));
+        if let Some(profile_v1) = profile_v1 {
+            profile_v2 = Some(migrations::migrate_v1_to_v2::convert_profile(profile_v1));
         } else {
             let filename = format!("profile_v{}.json", PROFILE_CURRENT_VERSION);
             let path = Path::new(filename.as_str());
@@ -64,11 +61,7 @@ pub fn read_latest_profile() -> Result<profile::ProfileConfiguration, String> {
         }
     }
 
-    if profile_v2.is_some() {
-        return Ok(profile_v2.unwrap());
-    } else {
-        return Err("ERROR: No saved profiles found. Use download option first!".to_string());
-    }
+    return profile_v2.ok_or_else(|| "ERROR: No saved profiles found. Use download option first!".to_string());
 }
 
 pub fn get_latest_profile_name() -> String {

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -124,7 +124,7 @@ pub fn construct_profile(original_profile: &site::GetSiteResponse) -> ProfileCon
 
 fn parse_url(actor_id: String) -> String {
     let removed_begin = actor_id.strip_prefix("https://").unwrap_or(&actor_id);
-    let split_url: Vec<&str> = removed_begin.split("/").collect();
+    let split_url: Vec<&str> = removed_begin.split('/').collect();
     return format!("{}@{}", split_url.get(2).unwrap(), split_url.first().unwrap());
 }
 

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -125,7 +125,7 @@ pub fn construct_profile(original_profile: &site::GetSiteResponse) -> ProfileCon
 fn parse_url(actor_id: String) -> String {
     let removed_begin = actor_id.strip_prefix("https://").unwrap_or(&actor_id);
     let split_url: Vec<&str> = removed_begin.split("/").collect();
-    return format!("{}@{}", split_url.get(2).unwrap(), split_url.get(0).unwrap());
+    return format!("{}@{}", split_url.get(2).unwrap(), split_url.first().unwrap());
 }
 
 fn calculate_users_to_block(original_profile: &ProfileConfiguration, new_profile: &ProfileConfiguration) -> Vec<String> {


### PR DESCRIPTION
This PR applies several suggestions from [clippy](https://github.com/rust-lang/rust-clippy), the built-in Rust linter designed to "catch common mistakes and improve your Rust code". Running `cargo clippy` on `main` currently produces 66 warnings, after this PR there are 0. Most of these suggestions are about style, so please feel free to only accept some or none of this PR if they don't align with your coding style! I can remove any commits you don't want to merge, just let me know.

Each lint is in its own commit. You can search up each of the lints on the [clippy lints](https://rust-lang.github.io/rust-clippy/master/index.html) website to see why clippy suggests them.

This compiles and I did a basic profile download without any issues, but I didn't test more thoroughly than that.

If you want to enable clippy hints in your dev environment, in VS Code, you can [go to settings and set `rust-analyzer.check.command` to `clippy`](https://rust-analyzer.github.io/manual.html#clippy), [for helix you can follow these instructions](https://github.com/helix-editor/helix/wiki/How-to-install-the-default-language-servers#rust), otherwise check the internet :)