### PR TITLE
feat: validate url as a Lemmy instance before making API requests

### DIFF
--- a/src/lemmy/api.rs
+++ b/src/lemmy/api.rs
@@ -1,4 +1,3 @@
-use futures::executor::block_on;
 use lemmy_api_common::sensitive::Sensitive;
 use lemmy_api_common::person;
 use lemmy_api_common::site;
@@ -18,22 +17,21 @@ pub struct Api {
 }
 
 impl Api {
-    pub fn new(instance: Url) -> Result<Api, Error> {
+    pub async fn new(instance: Url) -> Result<Api, Error> {
         let mut client_builder = ClientBuilder::new();
         client_builder = client_builder.user_agent("LASIM - https://github.com/CMahaff/lasim");
         let new_client = client_builder.build().unwrap();
 
         // Check if instance is an actual Lemmy url by checking getSite
-        block_on(
-            new_client
-                .get(
-                    instance
-                        .join("/api/v3/site")
-                        .expect("Instance url to be a url"),
-                )
-                .send(),
-        )?
-        .error_for_status()?;
+        new_client
+            .get(
+                instance
+                    .join("/api/v3/site")
+                    .expect("Instance url to be a url"),
+            )
+            .send()
+            .await?
+            .error_for_status()?;
 
         return Ok(Api {
             client: new_client,

--- a/src/lemmy/api.rs
+++ b/src/lemmy/api.rs
@@ -1,3 +1,4 @@
+use futures::executor::block_on;
 use lemmy_api_common::sensitive::Sensitive;
 use lemmy_api_common::person;
 use lemmy_api_common::site;
@@ -21,6 +22,18 @@ impl Api {
         let mut client_builder = ClientBuilder::new();
         client_builder = client_builder.user_agent("LASIM - https://github.com/CMahaff/lasim");
         let new_client = client_builder.build().unwrap();
+
+        // Check if instance is an actual Lemmy url by checking getSite
+        block_on(
+            new_client
+                .get(
+                    instance
+                        .join("/api/v3/site")
+                        .expect("Instance url to be a url"),
+                )
+                .send(),
+        )?
+        .error_for_status()?;
 
         return Ok(Api {
             client: new_client,

--- a/src/lemmy/api.rs
+++ b/src/lemmy/api.rs
@@ -17,15 +17,15 @@ pub struct Api {
 }
 
 impl Api {
-    pub fn new(instance: Url) -> Api {
+    pub fn new(instance: Url) -> Result<Api, Error> {
         let mut client_builder = ClientBuilder::new();
         client_builder = client_builder.user_agent("LASIM - https://github.com/CMahaff/lasim");
         let new_client = client_builder.build().unwrap();
 
-        return Api {
+        return Ok(Api {
             client: new_client,
             instance,
-        }
+        })
     }
 
     pub async fn login(&self, username: &str, password: &str, two_factor_token: Option<String>) -> Result<String, Error> {

--- a/src/lemmy/api.rs
+++ b/src/lemmy/api.rs
@@ -24,11 +24,7 @@ impl Api {
 
         // Check if instance is an actual Lemmy url by checking getSite
         new_client
-            .get(
-                instance
-                    .join("/api/v3/site")
-                    .expect("Instance url to be a url"),
-            )
+            .get(instance.join("/api/v3/site").unwrap())
             .send()
             .await?
             .error_for_status()?;
@@ -36,7 +32,7 @@ impl Api {
         return Ok(Api {
             client: new_client,
             instance,
-        })
+        });
     }
 
     pub async fn login(&self, username: &str, password: &str, two_factor_token: Option<String>) -> Result<String, Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,9 +182,12 @@ async fn process_download(processing_instruction: ProcessingInstruction, mut log
     }
     let instance_url = instance_url_result.unwrap();
 
-    let Ok(api) = lemmy::api::Api::new(instance_url).await else { 
-        logger("ERROR: Invalid Instance URL".to_string());
-        return
+    let api = match lemmy::api::Api::new(instance_url).await {
+        Ok(api) => api,
+        Err(e) => { 
+            logger(format!("ERROR: Invalid Instance URL (or instance is down) - {e}"));
+            return
+        }
     };
 
     // Login
@@ -373,9 +376,12 @@ async fn process_upload(processing_instruction: ProcessingInstruction, mut logge
     }
     let instance_url = instance_url_result.unwrap();
 
-    let Ok(api) = lemmy::api::Api::new(instance_url).await else { 
-        logger("ERROR: Invalid Instance URL".to_string());
-        return;
+    let api = match lemmy::api::Api::new(instance_url).await {
+        Ok(api) => api,
+        Err(e) => { 
+            logger(format!("ERROR: Invalid Instance URL (or instance is down) - {e}"));
+            return
+        }
     };
 
     // Login

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,9 +184,11 @@ async fn process_download(processing_instruction: ProcessingInstruction, mut log
 
     let api = match lemmy::api::Api::new(instance_url).await {
         Ok(api) => api,
-        Err(e) => { 
-            logger(format!("ERROR: Invalid Instance URL (or instance is down) - {e}"));
-            return
+        Err(e) => {
+            logger(format!(
+                "ERROR: Invalid Instance URL (or instance is down) - {e}"
+            ));
+            return;
         }
     };
 
@@ -378,9 +380,11 @@ async fn process_upload(processing_instruction: ProcessingInstruction, mut logge
 
     let api = match lemmy::api::Api::new(instance_url).await {
         Ok(api) => api,
-        Err(e) => { 
-            logger(format!("ERROR: Invalid Instance URL (or instance is down) - {e}"));
-            return
+        Err(e) => {
+            logger(format!(
+                "ERROR: Invalid Instance URL (or instance is down) - {e}"
+            ));
+            return;
         }
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,7 +182,10 @@ async fn process_download(processing_instruction: ProcessingInstruction, mut log
     }
     let instance_url = instance_url_result.unwrap();
 
-    let api = lemmy::api::Api::new(instance_url);
+    let Ok(api) = lemmy::api::Api::new(instance_url) else { 
+        logger("ERROR: Invalid Instance URL".to_string());
+        return
+    };
 
     // Login
     logger(format!("Logging in as {}", username));
@@ -370,7 +373,10 @@ async fn process_upload(processing_instruction: ProcessingInstruction, mut logge
     }
     let instance_url = instance_url_result.unwrap();
 
-    let api = lemmy::api::Api::new(instance_url);
+    let Ok(api) = lemmy::api::Api::new(instance_url) else { 
+        logger("ERROR: Invalid Instance URL".to_string());
+        return;
+    };
 
     // Login
     logger(format!("Logging in as {}", username));

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,7 +182,7 @@ async fn process_download(processing_instruction: ProcessingInstruction, mut log
     }
     let instance_url = instance_url_result.unwrap();
 
-    let Ok(api) = lemmy::api::Api::new(instance_url) else { 
+    let Ok(api) = lemmy::api::Api::new(instance_url).await else { 
         logger("ERROR: Invalid Instance URL".to_string());
         return
     };
@@ -373,7 +373,7 @@ async fn process_upload(processing_instruction: ProcessingInstruction, mut logge
     }
     let instance_url = instance_url_result.unwrap();
 
-    let Ok(api) = lemmy::api::Api::new(instance_url) else { 
+    let Ok(api) = lemmy::api::Api::new(instance_url).await else { 
         logger("ERROR: Invalid Instance URL".to_string());
         return;
     };


### PR DESCRIPTION
Closes #14. This checks that a `getSite` call returns without error before allowing `Api` queries to the URL. This ensures credentials are only sent to Lemmy instances and prevents simple attempts at stealing credentials by typosquatting.

| main | this PR |
| ------------- | ------------- |
| ![main](https://github.com/CMahaff/lasim/assets/47428697/e7963c67-7456-4400-9002-bd5cbbce5065) | ![getsite](https://github.com/CMahaff/lasim/assets/47428697/5fb77929-9a7d-4389-9d84-64f2bf3a07a3) |
| Fails *after* sending username / password to URL, even though it's not a lemmy instance | Fails *before* sending username / password, since the URL isn't a lemmy instance |

Creation of an `Api` now returns a `Result`, as the `Api` will fail to be created if the url does not return successfully from a `getSite` query.

I opted against checking the data returned from the `getSite` query  - I figure any malicious actors who would spoof a `getSite` query to seem like a Lemmy instance would just spin up a full Lemmy instance so any validation like that wouldn't be useful, let me know if I'm thinking about that the wrong way. I have ideas for providing a dropdown of common Lemmy instances to really try to mitigate typosquatting, but that's a future issue/PR.

Let me know if you have alternate solutions in mind or anything else you'd like me to change!