### PR TITLE
Allow window resizing

### DIFF
--- a/src/ui/app.slint
+++ b/src/ui/app.slint
@@ -28,8 +28,10 @@ export component App inherits Window {
     in property <bool> write_api_profiles <=> settings_page.write_api_profiles;
 
     title: "LASIM";
-    width: 280px;
-    height: 440px;
+    min-width: 280px;
+    min-height: 440px;
+    preferred-width: 280px;
+    preferred-height: 440px;
 
     VerticalBox {
         alignment: start;

--- a/src/ui/control_page.slint
+++ b/src/ui/control_page.slint
@@ -14,36 +14,43 @@ export component ControlPage inherits VerticalBox {
     in property <string> log_output;
     in property <bool> ui_enabled: true;
 
-    alignment: start;
+    alignment: stretch;
 
     instance_url_object := LineEdit {
+        vertical-stretch: 0;
         placeholder-text: "Instance URL";
-        width: 250px;
+        min-width: 250px;
         enabled: ui_enabled;
     }
     username_input_object := LineEdit {
+        vertical-stretch: 0;
         placeholder-text: "Username/Email";
-        width: 250px;
+        min-width: 250px;
         enabled: ui_enabled;
     }
     password_input_object := LineEdit {
+        vertical-stretch: 0;
         placeholder-text: "Password";
         input-type: password;
-        width: 250px;
+        min-width: 250px;
         enabled: ui_enabled;
     }
     two_factor_input_object := LineEdit {
+        vertical-stretch: 0;
         placeholder-text: "2FA Token (if enabled)";
-        width: 250px;
+        min-width: 250px;
         enabled: ui_enabled;
     }
 
     HorizontalLayout {
-        alignment: start;
+        vertical-stretch: 1;
+        alignment: stretch;
         VerticalLayout {
-        width: 250px;
+            min-width: 250px;
+            alignment: stretch;
             HorizontalBox {
                 alignment: center;
+                vertical-stretch: 0;
                 Button {
                     text: type;
                     width: 120px;
@@ -53,20 +60,14 @@ export component ControlPage inherits VerticalBox {
                     }
                 }
             }
-            ScrollView {
-                width: 250px;
-                height: 170px;
-                viewport-height: 4000px;
-                viewport-width: 200px;
-                TextEdit {
-                    wrap: word-wrap;
-                    read-only: true;
-                    width: 250px;
-                    x: 0;
-                    y:0;
-                    horizontal-alignment: left;
-                    text: log_output;
-                }
+            TextEdit {
+                vertical-stretch: 1;
+                min-width: 250px;
+                min-height: 170px;
+                wrap: word-wrap;
+                read-only: true;
+                horizontal-alignment: left;
+                text: log_output;
             }
         }
     }


### PR DESCRIPTION
Allow resizing of the main window and make various components stretchable to make use of the extra space.

NOTE: I also removed the ScrollView since it seemed only to be used for the log output and slints TextEdit seems to handle scrolling internally just fine

My main motivation was that on my system (linux, 4k screen running on plasma/wayland) various Tabs were clipped outside the window (my guess is slints pixels are physical pixels, not logical pixels but fonts are scaled correctly so the window ends up too small for its contents)

If you do consider this PR (not sure you  want a resizable UI at all, static sizes are easier to maintain after all) you might want to take my changes with a few extra grains of salt as I never used slint before